### PR TITLE
166038096 Fix bug on getting articles created by a user

### DIFF
--- a/src/routes/api/users/userController.js
+++ b/src/routes/api/users/userController.js
@@ -105,10 +105,11 @@ class Users {
       const limit = req.query.limit ? req.query.limit : 30;
       const offset = req.query.page ? limit * (req.query.page - 1) : 0;
       const currentPage = req.query.page ? req.query.page : 1;
+      const { userId } = req.params;
       const { count, rows } = await articles.findAndCountAll({
         offset,
         limit,
-        where: { author: req.user.id },
+        where: { author: userId },
         include: [
           {
             model: users,

--- a/src/routes/api/users/usersRoute.js
+++ b/src/routes/api/users/usersRoute.js
@@ -21,7 +21,7 @@ usersRoute.post('/forgotpassword', validate.forgotPassword, sendPasswordResetTok
 usersRoute.patch('/resetpassword', validate.resetPassword, resetPassword);
 usersRoute.get('/', checkToken, authorizeAdmin, Users.getAllUsers);
 usersRoute.patch('/', validate.validateUpdateUser, checkToken, Users.updateUser);
-usersRoute.get('/articles', checkToken, getUserArticles);
+usersRoute.get('/articles/:userId', checkToken, getUserArticles);
 usersRoute.get('/home', (req, res) => {
   res.send('every damn thing is working fine');
 });

--- a/test/articleTest.js
+++ b/test/articleTest.js
@@ -13,6 +13,7 @@ const user = {
 
 let testToken;
 let articleId;
+let userId;
 
 before(async () => {
   await models.sequelize.sync({ force: true });
@@ -21,6 +22,7 @@ before(async () => {
     .send(user);
   expect(result.body.user).to.be.an('object');
   testToken = result.body.user.token;
+  userId = result.body.user.userid;
 });
 
 describe('Article', () => {
@@ -461,7 +463,7 @@ describe('article reporting', () => {
 
   it('it should return the articles created by a specific user', async () => {
     const result = await server
-      .get('/api/v1/users/articles')
+      .get(`/api/v1/users/articles/${userId}`)
       .set('authorization', testToken)
       .expect(200);
     expect(result.status).to.equal(200);


### PR DESCRIPTION
#### Description 
This PR fixes the bug on 'getUserArticle' endpoint. Initially, this endpoint gets the article for any user whose token is sent. This meant that we could only get the articles of the signed in user. but it has been changed to get the articles of any user whose id is sent so that we can get the right details on the profile page

#### Type of change
bug

#### Pivotal tracker id
166038096